### PR TITLE
fix: pin whisperx before breaking change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN poetry install
 RUN /app/.venv/bin/pip install pandas transformers nltk pyannote.audio
 RUN git clone --depth 1 https://github.com/m-bain/whisperX.git \
     && cd whisperX \
+    && git checkout d97cdb7bcf302fb3e1651321a5935f90594e994c \
     && $POETRY_VENV/bin/pip install -e .
 
 EXPOSE 9000

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -40,7 +40,7 @@ RUN /app/.venv/bin/pip install torch torchaudio pandas transformers nltk pyannot
     --index-url https://download.pytorch.org/whl/cu118 \
     --index-url https://pypi.org/simple/
 
-RUN git clone --depth 1 https://github.com/m-bain/whisperX.git \
+RUN git clone https://github.com/m-bain/whisperX.git \
     && cd whisperX \
     && git checkout d97cdb7bcf302fb3e1651321a5935f90594e994c \
     && $POETRY_VENV/bin/pip install --no-dependencies -e .

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -42,6 +42,7 @@ RUN /app/.venv/bin/pip install torch torchaudio pandas transformers nltk pyannot
 
 RUN git clone --depth 1 https://github.com/m-bain/whisperX.git \
     && cd whisperX \
+    && git checkout d97cdb7bcf302fb3e1651321a5935f90594e994c \
     && $POETRY_VENV/bin/pip install --no-dependencies -e .
 
 EXPOSE 9000


### PR DESCRIPTION
Per the convo here: https://github.com/ahmetoner/whisper-asr-webservice/pull/125#issuecomment-1861725446 

I've modified both Dockerfiles to pin these. Whisperx hasn't been integrated into the upstream pyproject; I don't see anywhere else that it's provided as a dependency. 

Also, I did not look into the root cause of the breaking change to the whisperx package, but I'm pasting the error message here: 
```
AttributeError: 'WhisperModel' object has no attribute 'feat_kwargs'
[2024-01-27 13:37:17 +0000] [28] [ERROR] Exception in ASGI application
Traceback (most recent call last):
  File "/app/.venv/lib/python3.10/site-packages/uvicorn/protocols/http/httptools_impl.py", line 404, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/app/.venv/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/app/.venv/lib/python3.10/site-packages/fastapi/applications.py", line 276, in __call__
    await super().__call__(scope, receive, send)
  File "/app/.venv/lib/python3.10/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/app/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/app/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/app/.venv/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/app/.venv/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/app/.venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/app/.venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/app/.venv/lib/python3.10/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/app/.venv/lib/python3.10/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/app/.venv/lib/python3.10/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/app/.venv/lib/python3.10/site-packages/fastapi/routing.py", line 237, in app
    raw_response = await run_endpoint_function(
  File "/app/.venv/lib/python3.10/site-packages/fastapi/routing.py", line 165, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/app/.venv/lib/python3.10/site-packages/starlette/concurrency.py", line 41, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "/app/.venv/lib/python3.10/site-packages/anyio/to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/app/.venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "/app/.venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "/app/app/webservice.py", line 91, in asr
    result = transcribe(
  File "/app/app/mbain_whisperx/core.py", line 41, in transcribe
    result = model.transcribe(audio, **options_dict)
  File "/app/whisperX/whisperx/asr.py", line 194, in transcribe
    language = language or self.detect_language(audio)
  File "/app/whisperX/whisperx/asr.py", line 248, in detect_language
    model_n_mels = self.model.feat_kwargs.get("feature_size")
AttributeError: 'WhisperModel' object has no attribute 'feat_kwargs'

```